### PR TITLE
Handle deprecated random module

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,8 +2,6 @@
     {"priv/b64url.so", ["c_src/*.c"]}
 ]}.
 
-{eunit_opts, [verbose]}.
-
 {port_env, [
     % Development compilation
     % {".*", "CFLAGS", "$CFLAGS -g -Wall -Werror -fPIC"}
@@ -13,3 +11,16 @@
     {"win32", "CFLAGS", "$CFLAGS /O2 /DNDEBUG /Wall"}
 
 ]}.
+
+{eunit_opts, [verbose]}.
+
+{erl_opts, [
+   {platform_define, "^R16", 'NORANDMODULE'},
+   {platform_define, "^17", 'NORANDMODULE'}
+]}.
+
+{eunit_compile_opts, [
+   {platform_define, "^R16", 'NORANDMODULE'},
+   {platform_define, "^17", 'NORANDMODULE'}
+]}.
+

--- a/test/b64url_rand.erl
+++ b/test/b64url_rand.erl
@@ -1,0 +1,57 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(b64url_rand).
+
+
+-export([
+    uniform/0,
+    uniform/1
+]).
+
+
+-ifdef(NORANDMODULE).
+
+
+uniform() ->
+    maybe_set_random_seed(),
+    random:uniform().
+
+
+uniform(N) ->
+    maybe_set_random_seed(),
+    random:uniform(N).
+
+
+maybe_set_random_seed() ->
+    case get(random_seed) of
+        undefined ->
+            {_, Sec, USec} = os:timestamp(),
+            Seed = {erlang:phash2(self()), Sec, USec},
+            random:seed(Seed);
+        _ ->
+            ok
+    end.
+
+
+-else.
+
+
+uniform() ->
+    rand:uniform().
+
+
+uniform(N) ->
+    rand:uniform(N).
+
+
+-endif.

--- a/test/b64url_tests.erl
+++ b/test/b64url_tests.erl
@@ -64,7 +64,8 @@ decode_bad_length_test() ->
 
 
 gen_binary() ->
-    Length = crypto:rand_uniform(0, ?MAX_SIZE),
+    % -1 to allow for 0 length
+    Length = b64url_rand:uniform(?MAX_SIZE) - 1,
     crypto:strong_rand_bytes(Length).
 
 
@@ -85,31 +86,31 @@ bad_len_binary() ->
 
 
 to_iolist(<<>>) ->
-    case crypto:rand_uniform(0,2) of
-        0 -> <<>>;
-        1 -> [<<>>]
+    case b64url_rand:uniform(2) of
+        1 -> <<>>;
+        2 -> [<<>>]
     end;
 to_iolist(B) when is_binary(B), size(B) > 0 ->
-    S = crypto:rand_uniform(1, size(B) + 1),
+    S = b64url_rand:uniform(size(B)),
     <<First:S/binary, Second/binary>> = B,
-    case crypto:rand_uniform(0, 3) of
-        0 ->
-            [to_iolist(First), Second];
+    case b64url_rand:uniform(3) of
         1 ->
-            [First, to_iolist(Second)];
+            [to_iolist(First), Second];
         2 ->
+            [First, to_iolist(Second)];
+        3->
             [First, Second]
     end.
 
 
 insert_error(B) when is_binary(B), size(B) < 2 ->
-    case crypto:rand_uniform(0, 2) of
-        0 -> {<<122, 255>>, 0};
-        1 -> {<<122, 122, 255>>, 0}
+    case b64url_rand:uniform(2) of
+        1 -> {<<122, 255>>, 0};
+        2 -> {<<122, 122, 255>>, 0}
     end;
 insert_error(B) when is_binary(B) ->
     B64 = couch_encode_base64url(B),
-    S = crypto:rand_uniform(0, size(B64)),
+    S = b64url_rand:uniform(size(B64) - 1),
     <<First:S/binary, _:1/binary, Second/binary>> = B64,
     {<<First:S/binary, 255, Second/binary>>, 4 * (S div 4)}.
 

--- a/test/benchmark.escript
+++ b/test/benchmark.escript
@@ -115,7 +115,7 @@ run_worker(St, Started) ->
 
 
 do_round_trip(St) ->
-    Size = crypto:rand_uniform(St#st.minsize,  St#st.maxsize + 1),
+    Size = St#st.minsize + b64url_rand:uniform(St#st.maxsize - St#st.minsize),
     Data = crypto:strong_rand_bytes(Size),
     Encoded = (St#st.module):encode(Data),
     Data = (St#st.module):decode(Encoded),
@@ -137,7 +137,7 @@ decode(Url64) ->
     base64:decode(<<Url2/binary, Padding/binary>>).
 
 randomize(List) ->
-    List0 = [{crypto:rand_uniform(0, 1 bsl 32), L} || L <- List],
+    List0 = [{b64url_rand:uniform(), L} || L <- List],
     List1 = lists:sort(List0),
     [L || {_, L} <- List1].
 


### PR DESCRIPTION
Use a compile time check for platform versions, then a macro conditional in a
separate rand module.