### PR TITLE
Format code with erlfmt, run dialyzer in CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
     "image": "erlang:24",
     
     "extensions": [
-        "erlang-ls.erlang-ls"
+        "erlang-ls.erlang-ls",
+        "ms-vscode.cpptools"
     ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Setup Erlang
+        id: setup-beam
         uses: ./.github/actions/setup-beam
         with:
           otp-version: ${{ matrix.otp-version }}
@@ -34,10 +35,21 @@ jobs:
       - name: Setup MSVC toolchain
         if: ${{ matrix.os == 'windows-latest' }}
         uses: ./.github/actions/msvc-dev-cmd
+      - name: Check coding style with erlfmt
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: rebar3 fmt --check
+        continue-on-error: true
       - name: Compile
         run: rebar3 compile
       - name: EUnit tests
         run: rebar3 eunit
+      - name: Restore dialyzer PLT from cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/rebar3/rebar3_*_plt
+          key: ${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}
+      - name: Run dialyzer analysis
+        run: rebar3 as test dialyzer
       - name: Setup tmate session on job failure
         uses: ./.github/actions/tmate
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
-      # Set to 1 for verbose rebar3 logging
-      DEBUG: 0
-      # Set to 1 for even more verbose rebar3 logging
-      DIAGNOSTIC: 0
+      # Define to something other than empty string to enable verbose rebar3 logging
+      DEBUG: ''
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,18 @@ jobs:
         otp-version: ['22', '23', '24']
         # erlef/setup-beam action does not support macos yet
         os: [ubuntu-latest, windows-latest]
+        rebar3-version: ['3.17']
+        include:
+          - otp-version: '21'
+            os: ubuntu-latest
+            rebar3-version: '3.15.2'
+          - otp-version: '21'
+            os: windows-latest
+            rebar3-version: '3.15.2'
+          - otp-version: '20'
+            os: ubuntu-latest
+            rebar3-version: '3.15.2'
+
     runs-on: ${{ matrix.os }}
     env:
       # Define to something other than empty string to enable verbose rebar3 logging
@@ -31,7 +43,7 @@ jobs:
         uses: ./.github/actions/setup-beam
         with:
           otp-version: ${{ matrix.otp-version }}
-          rebar3-version: '3.17'
+          rebar3-version: ${{ matrix.rebar3-version }}
       - name: Setup MSVC toolchain
         if: ${{ matrix.os == 'windows-latest' }}
         uses: ./.github/actions/msvc-dev-cmd

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,6 @@
     % Production compilation
     {"(linux|solaris|darwin|freebsd)", "CFLAGS", "$CFLAGS -Wall -Werror -DNDEBUG -O3"},
     {"win32", "CFLAGS", "$CFLAGS /O2 /DNDEBUG /Wall"}
-
 ]}.
 
 {eunit_opts, [

--- a/src/b64url.erl
+++ b/src/b64url.erl
@@ -13,21 +13,17 @@
 -module(b64url).
 -on_load(init/0).
 
-
 -export([
     encode/1,
     decode/1
 ]).
-
 
 % Internal sanity checks
 -export([
     check_tables/0
 ]).
 
-
 -define(NOT_LOADED, not_loaded(?LINE)).
-
 
 -spec encode(iodata()) -> binary().
 encode(IoData) ->
@@ -37,7 +33,6 @@ encode(IoData) ->
         {partial, St} ->
             encode_loop(IoData, St)
     end.
-
 
 -spec decode(iodata()) -> binary() | {error, any()}.
 decode(IoData) ->
@@ -54,18 +49,17 @@ decode(IoData) ->
 check_tables() ->
     ?NOT_LOADED.
 
-
 init() ->
-    PrivDir = case code:priv_dir(?MODULE) of
-        {error, _} ->
-            EbinDir = filename:dirname(code:which(?MODULE)),
-            AppPath = filename:dirname(EbinDir),
-            filename:join(AppPath, "priv");
-        Path ->
-            Path
-    end,
+    PrivDir =
+        case code:priv_dir(?MODULE) of
+            {error, _} ->
+                EbinDir = filename:dirname(code:which(?MODULE)),
+                AppPath = filename:dirname(EbinDir),
+                filename:join(AppPath, "priv");
+            Path ->
+                Path
+        end,
     erlang:load_nif(filename:join(PrivDir, "b64url"), 0).
-
 
 encode_loop(IoData, St) ->
     case encode_cont(IoData, St) of
@@ -74,7 +68,6 @@ encode_loop(IoData, St) ->
         {partial, St} ->
             encode_loop(IoData, St)
     end.
-
 
 decode_loop(IoData, St) ->
     case decode_cont(IoData, St) of
@@ -86,13 +79,10 @@ decode_loop(IoData, St) ->
             decode_loop(IoData, St)
     end.
 
-
 encode_init(_) -> ?NOT_LOADED.
 encode_cont(_, _) -> ?NOT_LOADED.
 decode_init(_) -> ?NOT_LOADED.
 decode_cont(_, _) -> ?NOT_LOADED.
 
-
 not_loaded(Line) ->
     erlang:nif_error({not_loaded, [{module, ?MODULE}, {line, Line}]}).
-

--- a/test/b64url_tests.erl
+++ b/test/b64url_tests.erl
@@ -1,89 +1,92 @@
 -module(b64url_tests).
 
-
 -include_lib("eunit/include/eunit.hrl").
-
 
 -define(MAX_SIZE, 6401).
 -define(NUM_TESTS, 500).
 
-
 table_test() ->
     ?assertEqual(ok, b64url:check_tables()).
 
-
 encode_binary_test() ->
-    lists:foreach(fun(_) ->
-        Bin = gen_binary(),
-        A = couch_encode_base64url(Bin),
-        B = b64url:encode(Bin),
-        ?assertEqual(A, B)
-    end, lists:seq(1, ?NUM_TESTS)).
-
+    lists:foreach(
+        fun(_) ->
+            Bin = gen_binary(),
+            A = couch_encode_base64url(Bin),
+            B = b64url:encode(Bin),
+            ?assertEqual(A, B)
+        end,
+        lists:seq(1, ?NUM_TESTS)
+    ).
 
 encode_iolist_test() ->
-    lists:foreach(fun(_) ->
-        IoList = shallow_iolist(),
-        A = couch_encode_base64url(iolist_to_binary(IoList)),
-        B = b64url:encode(IoList),
-        ?assertEqual(A, B)
-    end, lists:seq(1, ?NUM_TESTS)).
-
+    lists:foreach(
+        fun(_) ->
+            IoList = shallow_iolist(),
+            A = couch_encode_base64url(iolist_to_binary(IoList)),
+            B = b64url:encode(IoList),
+            ?assertEqual(A, B)
+        end,
+        lists:seq(1, ?NUM_TESTS)
+    ).
 
 decode_binary_test() ->
-    lists:foreach(fun(_) ->
-        Bin = gen_binary(),
-        B64UrlBin = couch_encode_base64url(Bin),
-        Dec = b64url:decode(B64UrlBin),
-        ?assertEqual(Bin, Dec)
-    end, lists:seq(1, ?NUM_TESTS)).
-
+    lists:foreach(
+        fun(_) ->
+            Bin = gen_binary(),
+            B64UrlBin = couch_encode_base64url(Bin),
+            Dec = b64url:decode(B64UrlBin),
+            ?assertEqual(Bin, Dec)
+        end,
+        lists:seq(1, ?NUM_TESTS)
+    ).
 
 decode_iolist_test() ->
-    lists:foreach(fun(_) ->
-        IoList = shallow_b64_iolist(),
-        A = couch_decode_base64url(iolist_to_binary(IoList)),
-        B = b64url:decode(IoList),
-        ?assertEqual(A, B)
-    end, lists:seq(1, ?NUM_TESTS)).
-
+    lists:foreach(
+        fun(_) ->
+            IoList = shallow_b64_iolist(),
+            A = couch_decode_base64url(iolist_to_binary(IoList)),
+            B = b64url:decode(IoList),
+            ?assertEqual(A, B)
+        end,
+        lists:seq(1, ?NUM_TESTS)
+    ).
 
 decode_binary_error_test() ->
-    lists:foreach(fun(_) ->
-        {ErrBin, BlockPos} = bad_binary(),
-        Dec = b64url:decode(ErrBin),
-        ?assertEqual({error, {bad_block, BlockPos}}, Dec)
-    end, lists:seq(1, ?NUM_TESTS)).
-
+    lists:foreach(
+        fun(_) ->
+            {ErrBin, BlockPos} = bad_binary(),
+            Dec = b64url:decode(ErrBin),
+            ?assertEqual({error, {bad_block, BlockPos}}, Dec)
+        end,
+        lists:seq(1, ?NUM_TESTS)
+    ).
 
 decode_bad_length_test() ->
-    lists:foreach(fun(_) ->
-        Bin = bad_len_binary(),
-        ?assertError(badarg, b64url:decode(Bin))
-    end, lists:seq(1, ?NUM_TESTS)).
-
+    lists:foreach(
+        fun(_) ->
+            Bin = bad_len_binary(),
+            ?assertError(badarg, b64url:decode(Bin))
+        end,
+        lists:seq(1, ?NUM_TESTS)
+    ).
 
 gen_binary() ->
     % -1 to allow for 0 length
     Length = rand:uniform(?MAX_SIZE) - 1,
     crypto:strong_rand_bytes(Length).
 
-
 shallow_iolist() ->
     to_iolist(gen_binary()).
-
 
 shallow_b64_iolist() ->
     to_iolist(couch_encode_base64url(gen_binary())).
 
-
 bad_binary() ->
     insert_error(gen_binary()).
 
-
 bad_len_binary() ->
     make_bad_len(gen_binary()).
-
 
 to_iolist(<<>>) ->
     case rand:uniform(2) of
@@ -98,10 +101,9 @@ to_iolist(B) when is_binary(B), size(B) > 0 ->
             [to_iolist(First), Second];
         2 ->
             [First, to_iolist(Second)];
-        3->
+        3 ->
             [First, Second]
     end.
-
 
 insert_error(B) when is_binary(B), size(B) < 2 ->
     case rand:uniform(2) of
@@ -114,7 +116,6 @@ insert_error(B) when is_binary(B) ->
     <<First:S/binary, _:1/binary, Second/binary>> = B64,
     {<<First:S/binary, 255, Second/binary>>, 4 * (S div 4)}.
 
-
 make_bad_len(Bin) when size(Bin) rem 4 == 1 ->
     Bin;
 make_bad_len(Bin) when size(Bin) rem 4 == 2 ->
@@ -124,18 +125,15 @@ make_bad_len(Bin) when size(Bin) rem 4 == 3 ->
 make_bad_len(Bin) when size(Bin) rem 4 == 0 ->
     <<"A", Bin/binary>>.
 
-
 % These functions are copy/pasted from couch_util to avoid
 % the direct dependency. The goal of this project is to replace
 % these in couch_util anyway so when that happens they'll only
 % exist here for these tests.
 
-
 couch_encode_base64url(Url) ->
     Url1 = iolist_to_binary(re:replace(base64:encode(Url), "=+$", "")),
     Url2 = iolist_to_binary(re:replace(Url1, "/", "_", [global])),
     iolist_to_binary(re:replace(Url2, "\\+", "-", [global])).
-
 
 couch_decode_base64url(Url64) ->
     Url1 = re:replace(iolist_to_binary(Url64), "-", "+", [global]),


### PR DESCRIPTION
Here's the summary:

- [x] Extend CI matrix to OTP 20-24 to ensure continued support in CouchDB 3.x (21-24 for Windows)
- [x] Format code with erlfmt
- [x] Run erlfmt in CI but don't fail on violations -- erlfmt is only compatible with 21+
- [x] Run dialyzer in CI, caching PLT between runs to avoid overhead
- [x] Fix accidental debug logging enablement
- [x] Add C/C++ extension in .devcontainer (unrelated, but still useful)

Closes #10 