### PR TITLE
Prep for ASF source release publication

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.asf.yaml           export-ignore
+.devcontainer/      export-ignore
+.gitattributes      export-ignore
+.github/            export-ignore
+.gitignore          export-ignore
+.gitmodules         export-ignore

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,15 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
 REBAR?=rebar
 
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-REBAR?=rebar
+REBAR?=rebar3
 
 
 .PHONY: all
@@ -33,7 +33,6 @@ check: build eunit
 # target: clean - Removes build artifacts
 clean:
 	$(REBAR) clean
-	rm -f test/*.beam
 
 
 .PHONY: distclean
@@ -52,7 +51,3 @@ eunit:
 # target: help - Prints this help
 help:
 	@egrep "^# target:" Makefile | sed -e 's/^# target: //g' | sort
-
-
-%.beam: %.erl
-	erlc -o test/ $<

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 
 REBAR?=rebar3
 
+VERSION = $(shell git describe --tags --always --first-parent)
 
 .PHONY: all
 # target: all - Makes everything
@@ -27,6 +28,19 @@ build:
 .PHONY: check
 # target: check - Checks if project builds and passes all the tests
 check: build eunit
+
+
+.PHONY: dist
+# target: dist - Generate source release
+# A little bit of explanation for the untar + sed + tar dance below.
+# During development we dynamically generate the vsn in the .app file
+# using {vsn, git}. We can't do that in the actual source release
+# because it's not a git repo, so we inject the version string into the
+# archived app.src file and then repackage the archive for shipping.
+dist:
+	@git archive --prefix=b64url-${VERSION}/ HEAD | tar xf -
+	@sed --in-place -e "s/{vsn, git}/{vsn, \"${VERSION}\"}/" b64url-${VERSION}/src/b64url.app.src
+	@tar czf b64url-${VERSION}.tar.gz b64url-${VERSION}
 
 
 .PHONY: clean

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Apache CouchDB Components - URL safe Base64 encoder
+Copyright 2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,15 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+% http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
 {plugins, [
     pc
 ]}.

--- a/src/b64url.app.src
+++ b/src/b64url.app.src
@@ -11,8 +11,10 @@
 % the License.
 
 {application, b64url, [
-    {description, "A small NIF for encoding Base64 URL encoding/decoding."},
+    {description, "URL-safe Base64 encoder"},
     {vsn, git},
     {registered, []},
-    {applications, [kernel, stdlib]}
+    {applications, [kernel, stdlib]},
+    {licenses, ["Apache 2.0"]},
+    {links, [{"GitHub", "https://github.com/apache/couchdb-b64url"}]}
 ]}.

--- a/test/b64url_tests.erl
+++ b/test/b64url_tests.erl
@@ -1,3 +1,15 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+% http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
 -module(b64url_tests).
 
 -include_lib("eunit/include/eunit.hrl").

--- a/test/benchmark.escript
+++ b/test/benchmark.escript
@@ -1,5 +1,17 @@
 #!/usr/bin/env escript
 
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+% http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
 -mode(compile).
 
 


### PR DESCRIPTION
This is an attempt to get the codebase ready for a release candidate that we could vote on as the CouchDB community. In particular, I added a `make dist` target that should hopefully produce a tarball that would be suitable for signing and uploading to the ASF as a release candidate. I added a few missing license headers and the required NOTICE file, and I also tweaked the app.src file to meet the requirements of the Hex package manager, under the assumption that a successful release would be something that we'd promptly publish to hex.pm.